### PR TITLE
feat: Add flag to disable the use of HTTP HEAD verb

### DIFF
--- a/snakemake_storage_plugin_http/__init__.py
+++ b/snakemake_storage_plugin_http/__init__.py
@@ -82,6 +82,12 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "help": "Allow redirects when retrieving files.",
         },
     )
+    supports_http_head: Optional[bool] = field(
+        default=True,
+        metadata={
+            "help": "Whether the storage provider supports HTTP HEAD requests.",
+        },
+    )
 
 
 # Required:
@@ -213,7 +219,10 @@ class StorageObject(StorageObjectRead):
             if verb.upper() == "GET":
                 request = partial(requests.get, stream=stream)
             if verb.upper() == "HEAD":
-                request = requests.head
+                if self.provider.settings.supports_http_head:
+                    request = requests.head
+                else:
+                    request = requests.get
 
             r = request(
                 self.query,

--- a/snakemake_storage_plugin_http/__init__.py
+++ b/snakemake_storage_plugin_http/__init__.py
@@ -82,7 +82,7 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "help": "Allow redirects when retrieving files.",
         },
     )
-    supports_http_head: Optional[bool] = field(
+    supports_head: Optional[bool] = field(
         default=True,
         metadata={
             "help": "Whether the storage provider supports HTTP HEAD requests.",

--- a/snakemake_storage_plugin_http/__init__.py
+++ b/snakemake_storage_plugin_http/__init__.py
@@ -219,7 +219,7 @@ class StorageObject(StorageObjectRead):
             if verb.upper() == "GET":
                 request = partial(requests.get, stream=stream)
             if verb.upper() == "HEAD":
-                if self.provider.settings.supports_http_head:
+                if self.provider.settings.supports_head:
                     request = requests.head
                 else:
                     request = requests.get


### PR DESCRIPTION
Provides an option to disable the use of the HTTP HEAD verb for servers that don't allow that. Fixes #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional attribute to indicate if the storage provider supports HTTP HEAD requests, enhancing flexibility in HTTP request handling.
- **Bug Fixes**
	- Improved logic for handling HTTP requests based on the new attribute, ensuring appropriate method usage based on storage provider capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->