### PR TITLE
fix: decompress transparently compressed data

### DIFF
--- a/snakemake_storage_plugin_http/__init__.py
+++ b/snakemake_storage_plugin_http/__init__.py
@@ -191,21 +191,9 @@ class StorageObject(StorageObjectRead):
 
     def retrieve_object(self):
         with self.httpr(stream=True) as httpr:
-            # Find out if the source file is gzip compressed in order to keep
-            # compression intact after the download.
-            # Per default requests decompresses .gz files.
-            # More details can be found here:
-            # https://stackoverflow.com/questions/25749345/how-to-download-gz-files-with-requests-in-python-without-decoding-it?noredirect=1&lq=1  # noqa E501
-            # Since data transferred with HTTP compression need to be decompressed
-            # automatically, check the header and decode if the content is encoded.
-            if (
-                not self.query.endswith(".gz")
-                and httpr.headers.get("Content-Encoding") == "gzip"
-            ):
-                # Decode non-gzipped sourcefiles automatically.
-                # This is needed to decompress uncompressed files that are compressed
-                # for the transfer by HTTP compression.
-                httpr.raw.decode_content = True
+            # Make sure that transparently compressed data is decompressed correctly,
+            # refer also to https://httpwg.org/specs/rfc9110.html#field.content-encoding
+            httpr.raw.decode_content = bool(httpr.headers.get("Content-Encoding"))
             # if the destination path does not exist
             os.makedirs(os.path.dirname(self.local_path()), exist_ok=True)
             with open(self.local_path(), "wb") as f:


### PR DESCRIPTION
Fixes #29.

We remove the custom workaround which broke downloading of transparently compressed files, like the brotli encoded file in the linked issue.

The [original stackoverflow question](https://stackoverflow.com/questions/25749345/how-to-download-gz-files-with-requests-in-python-without-decoding-it?noredirect=1&lq=1) cited as a reason for special casing the decode_content flag, claims that it was unable to download a gzip encoded file unless decode_content was unset.

According to the spec in [rfc9110](https://httpwg.org/specs/rfc9110.html#field.content-encoding) the content-encoding header should not be set unless it was explicitly transparently compressed and that is correct for the servers i verified:
```
>>> import requests
>>> res = requests.get("https://wiki.mozilla.org/images/f/ff/Example.json.gz")
>>> bool(res.headers.get("Content-Encoding"))
False
```

Therefore, we can use the presence of Content-Encoding to exactly determine whether to decode the content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP content encoding handling to automatically decompress compressed responses based on the Content-Encoding header, ensuring proper decompression of gzip-encoded content from HTTP sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->